### PR TITLE
Create interactive Docker Compose service management commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/FelipeMCassiano/gorvus
 
 go 1.22.1
 
-require github.com/spf13/cobra v1.8.0
+require (
+	github.com/spf13/cobra v1.8.0
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,7 @@ github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/commands/composeAdd.go
+++ b/internal/commands/composeAdd.go
@@ -1,0 +1,114 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+func CreateComposeCommand() *cobra.Command {
+	var serviceNameFlag string
+
+	composeCmd := &cobra.Command{
+		Use:   "compose",
+		Short: "Manages current directory's docker-compose.yml",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("use add or remove to manage your docker-compose with gorvus.")
+		},
+	}
+
+	composeAddCmd := &cobra.Command{
+		Use:   "add",
+		Short: "Adds a new service into docker-compose.yml",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 0 {
+				fmt.Println("invalid arguments given, the add command accepts a single argument that is the image to be added.")
+				fmt.Println("tip: you can also set a custom service name by using the --name flag")
+				return
+			}
+
+			workingDir, getWdError := os.Getwd()
+			if getWdError != nil {
+				fmt.Println("oops! could not get current working directory.")
+				return
+			}
+
+			dockerComposePath := path.Join(workingDir, "docker-compose.yml")
+			dockerComposeFileInfo, statComposeError := os.Stat(dockerComposePath)
+			if statComposeError != nil {
+				fmt.Println("for some reason, it failed to read docker-compose.yml file.")
+				return
+			}
+
+			// todo fallback to empty composeYml
+			dockerComposeFileContents, readComposeError := os.ReadFile(dockerComposePath)
+			if readComposeError != nil {
+				fmt.Println("for some reason, it failed to read docker-compose.yml file.")
+				return
+			}
+
+			composeYml := make(map[string]interface{})
+			yamlParseError := yaml.Unmarshal(dockerComposeFileContents, composeYml)
+			if yamlParseError != nil {
+				fmt.Println("can't manage docker-compose.yml, the contents of the file are invalid.")
+				return
+			}
+
+			selectedImage := args[0]
+
+			// use image name as defaults if service name is not set
+			if serviceNameFlag == "" {
+				serviceNameFlag = selectedImage
+			}
+
+			// todo use templating file
+			service := map[string]interface{}{
+				"name":  serviceNameFlag,
+				"image": selectedImage,
+			}
+
+			//! composeYml will be mutated
+			if addServiceError := ComposeAdd(&composeYml, serviceNameFlag, service); addServiceError != nil {
+				fmt.Println(addServiceError)
+				return
+			}
+
+			// reupdate yml file in disk
+			newComposeYmlAsBytes, marshalError := yaml.Marshal(composeYml)
+			if marshalError != nil {
+				fmt.Println("can't manage docker-compose.yml, the contents of the file are invalid.")
+				return
+			}
+
+			os.WriteFile(dockerComposePath, newComposeYmlAsBytes, dockerComposeFileInfo.Mode())
+			fmt.Println("service added to docker-compose.yml")
+		},
+	}
+
+	composeAddCmd.PersistentFlags().StringVarP(&serviceNameFlag, "name", "n", "", "sets the service name in docker-compose")
+
+	composeCmd.AddCommand(composeAddCmd)
+
+	return composeCmd
+}
+
+func ComposeAdd(compose *map[string]interface{}, serviceName string, service map[string]interface{}) error {
+	// todo check for version?
+	composeServices := (*compose)["services"].(map[string]interface{})
+
+	// search for conflicting service names
+	for inComposeServiceName := range composeServices {
+		if inComposeServiceName == serviceName {
+			return fmt.Errorf("%s is conflicting with a service with same name", serviceName)
+		}
+	}
+
+	// todo maybe prevent this side effect by returning new yml?
+	// add requested service into compose services
+	composeServices[serviceName] = service
+
+	return nil
+}

--- a/internal/commands/composeAdd.go
+++ b/internal/commands/composeAdd.go
@@ -97,6 +97,11 @@ func CreateComposeCommand() *cobra.Command {
 
 func ComposeAdd(compose *map[string]interface{}, serviceName string, service map[string]interface{}) error {
 	// todo check for version?
+	// is compose["services"] uninitialized? (kinda hacky, but it settles for now)
+	if (*compose)["services"] == nil {
+		(*compose)["services"] = make(map[string]interface{})
+	}
+
 	composeServices := (*compose)["services"].(map[string]interface{})
 
 	// search for conflicting service names

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -15,6 +15,7 @@ var rootCmd = &cobra.Command{
 
 func Execute() {
 	rootCmd.AddCommand(createDockerfile())
+	rootCmd.AddCommand(CreateComposeCommand())
 
 	err := rootCmd.Execute()
 	if err != nil {


### PR DESCRIPTION
This currently in draft PR features commands for interactively adding or removing services from `docker-compose.yml`.

#### Roadmap

- [x] Able to incrementally add new services by giving their images into `docker-compose.yml` using `compose add`.
- [ ] Use templates that configures environment variables instead of just adding service and images.
- [ ] Display prompts for configuring services from templates.

###### Brainstorming

- [ ] Able to remove services using `compose remove` command without needing to modifying `docker-compose.yml` directly. 

Closes #3 