### PR TITLE
feat: Add restart policy to compose builders

### DIFF
--- a/internal/builders/compose_builders/compose_builder.go
+++ b/internal/builders/compose_builders/compose_builder.go
@@ -11,6 +11,7 @@ type ComposeData struct {
 	DbUser       string
 	DbRootPass   string
 	DbPass       string
+	Restart      string
 	Ports        string
 	Cpu          string
 	Memory       string

--- a/internal/builders/compose_builders/mysql.builder.go
+++ b/internal/builders/compose_builders/mysql.builder.go
@@ -41,6 +41,7 @@ func setMyqslSettings() *ComposeData {
 		{"DB User (Default: USER)", &data.DbUser},
 		{"DB Root Password (Default: ROOT)", &data.DbRootPass},
 		{"DB Password (Default: PASS)", &data.DbPass},
+		{"Restart (Default: no)", &data.Restart},
 		{"Ports (Default: 3306:3306)", &data.Ports},
 		{"CPU (Default: 1)", &data.Cpu},
 		{"Memory (MB) (Default: 500)", &data.Memory},
@@ -75,6 +76,9 @@ func setMyqslSettings() *ComposeData {
 	}
 	if len(data.DbPass) == 0 {
 		data.DbPass = "PASS"
+	}
+	if len(data.Restart) == 0 {
+		data.Restart = "no"
 	}
 	if len(data.Ports) == 0 {
 		data.Ports = "3306:3306"

--- a/internal/builders/compose_builders/postgres_builder.go
+++ b/internal/builders/compose_builders/postgres_builder.go
@@ -41,6 +41,7 @@ func setPostgresSettings() *ComposeData {
 		{"DB Name (Default: DB)", &data.DbName},
 		{"DB User (Default: USER)", &data.DbUser},
 		{"DB Password (Default: PASS)", &data.DbPass},
+		{"Restart (Default: no)", &data.Restart},
 		{"Ports (Default: 5432:5432)", &data.Ports},
 		{"CPU (Default: 1)", &data.Cpu},
 		{"Memory (MB) (Default: 500)", &data.Memory},
@@ -75,6 +76,9 @@ func setPostgresSettings() *ComposeData {
 	}
 	if len(data.DbPass) == 0 {
 		data.DbPass = "PASS"
+	}
+	if len(data.Restart) == 0 {
+		data.Restart = "no"
 	}
 	if len(data.Ports) == 0 {
 		data.Ports = "5432:5432"

--- a/internal/builders/compose_builders/templates/mysql.tmpl
+++ b/internal/builders/compose_builders/templates/mysql.tmpl
@@ -9,7 +9,7 @@ services:
        MYSQL_USER: {{.DbUser}}
        MYSQL_ROOT_PASSWORD: {{.DbRootPass}}
        MYSQL_PASSWORD: {{.DbPass}}
-
+    restart: "{{.Restart}}"
     ports:
         - "{{.Ports}}"
     deploy:
@@ -19,4 +19,3 @@ services:
                 memory: "{{.Memory}}MB"
     networks:
       - {{.NetworkName}}
-    

--- a/internal/builders/compose_builders/templates/postgres.tmpl
+++ b/internal/builders/compose_builders/templates/postgres.tmpl
@@ -8,6 +8,7 @@ services:
        POSTGRES_DB: {{.DbName}}
        POSTGRES_USER: {{.DbUser}}
        POSTGRES_PASSWORD: {{.DbPass}}
+    restart: "{{.Restart}}"
     ports:
         - "{{.Ports}}"
     deploy:
@@ -17,4 +18,3 @@ services:
                 memory: "{{.Memory}}MB"
     networks:
       - {{.NetworkName}}
-


### PR DESCRIPTION
Add `restart` policy option when creating docker compose file (default to `no`)

Reference:

- [docs.docker.com#start-containers-automatically](https://docs.docker.com/config/containers/start-containers-automatically/#use-a-restart-policy)
