### PR TITLE
Modify workflow for Go releases with Goreleaser

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # For release uploads
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # For goreleaser
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Updated GitHub Actions workflow to trigger on tags for releases and removed build and test steps.